### PR TITLE
[SYCL-MLIR] Empty known_fail list

### DIFF
--- a/bin/run-suite
+++ b/bin/run-suite
@@ -50,9 +50,7 @@ app_list = {
       "vec_add"
     }
 
-known_fail = {"3DConvolution",
-      "DRAM",
-      "blocked_transform"}
+known_fail = {}
 
 is_bandwidth_bench = {
       "arith",


### PR DESCRIPTION
`3DConvolution`, `DRAM`, and `blocked_transform` are not failures.