### PR TITLE
Check double type support before using it in benchmarks

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -199,6 +199,10 @@ public:
     return args.cli.isFlagSet("--hierarchical-kernels");
   }
 
+  bool deviceHasAspect(cl::sycl::aspect asp) const { return device_queue.get_device().has(asp); }
+
+  bool deviceSupportsFP64() const { return deviceHasAspect(cl::sycl::aspect::fp64); }
+
   template<class Benchmark, typename... AdditionalArgs>
   void run(AdditionalArgs&&... additional_args)
   {

--- a/micro/DRAM.cpp
+++ b/micro/DRAM.cpp
@@ -102,9 +102,11 @@ int main(int argc, char** argv) {
   app.run<MicroBenchDRAM<float, 1>>();
   app.run<MicroBenchDRAM<float, 2>>();
   app.run<MicroBenchDRAM<float, 3>>();
-  app.run<MicroBenchDRAM<double, 1>>();
-  app.run<MicroBenchDRAM<double, 2>>();
-  app.run<MicroBenchDRAM<double, 3>>();
+  if(app.deviceSupportsFP64()) {
+    app.run<MicroBenchDRAM<double, 1>>();
+    app.run<MicroBenchDRAM<double, 2>>();
+    app.run<MicroBenchDRAM<double, 3>>();
+  }
 
   return 0;
 }

--- a/micro/arith.cpp
+++ b/micro/arith.cpp
@@ -91,7 +91,8 @@ int main(int argc, char** argv) {
 
   app.run<MicroBenchArithmetic<int>>();
   app.run<MicroBenchArithmetic<float>>();
-  app.run<MicroBenchArithmetic<double>>();
+  if(app.deviceSupportsFP64())
+    app.run<MicroBenchArithmetic<double>>();
 
   return 0;
 }

--- a/micro/local_mem.cpp
+++ b/micro/local_mem.cpp
@@ -99,7 +99,8 @@ int main(int argc, char** argv) {
   app.run<MicroBenchLocalMemory<float, compute_iters>>();
 
   // double precision
-  app.run<MicroBenchLocalMemory<double, compute_iters>>();
+  if(app.deviceSupportsFP64())
+    app.run<MicroBenchLocalMemory<double, compute_iters>>();
 
   return 0;
 }

--- a/micro/pattern_L2.cpp
+++ b/micro/pattern_L2.cpp
@@ -76,11 +76,13 @@ int main(int argc, char** argv)
   app.run< MicroBenchL2<float,16> >();
 
   // double precision
-  app.run< MicroBenchL2<double,1> >();
-  app.run< MicroBenchL2<double,2> >();
-  app.run< MicroBenchL2<double,4> >();
-  app.run< MicroBenchL2<double,8> >();
-  app.run< MicroBenchL2<double,16> >();
+  if(app.deviceSupportsFP64()) {
+    app.run<MicroBenchL2<double, 1>>();
+    app.run<MicroBenchL2<double, 2>>();
+    app.run<MicroBenchL2<double, 4>>();
+    app.run<MicroBenchL2<double, 8>>();
+    app.run<MicroBenchL2<double, 16>>();
+  }
 
   return 0;
 }

--- a/micro/sf.cpp
+++ b/micro/sf.cpp
@@ -85,7 +85,8 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
 
   app.run<MicroBenchSpecialFunc<float>>();
-  app.run<MicroBenchSpecialFunc<double>>();
+  if(app.deviceSupportsFP64())
+    app.run<MicroBenchSpecialFunc<double>>();
 
   return 0;
 }

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -257,14 +257,16 @@ int main(int argc, char** argv)
     app.run< ReductionNDRange<int>>();
     app.run< ReductionNDRange<long long>>();
     app.run< ReductionNDRange<float>>();
-    app.run< ReductionNDRange<double>>();
+    if(app.deviceSupportsFP64())
+      app.run<ReductionNDRange<double>>();
   }
   //app.run< ReductionHierarchical<short>>();
   if(app.shouldRunHierarchicalKernels()){
     app.run< ReductionHierarchical<int>>();
     app.run< ReductionHierarchical<long long>>();
     app.run< ReductionHierarchical<float>>();
-    app.run< ReductionHierarchical<double>>();
+    if(app.deviceSupportsFP64())
+      app.run<ReductionHierarchical<double>>();
   }
 
   return 0;

--- a/pattern/segmentedreduction.cpp
+++ b/pattern/segmentedreduction.cpp
@@ -201,7 +201,8 @@ int main(int argc, char** argv)
     app.run< SegmentedReductionNDRange<int>>();
     app.run< SegmentedReductionNDRange<long long>>();
     app.run< SegmentedReductionNDRange<float>>();
-    app.run< SegmentedReductionNDRange<double>>();
+    if(app.deviceSupportsFP64())
+      app.run<SegmentedReductionNDRange<double>>();
   }
 
   if(app.shouldRunHierarchicalKernels()) {
@@ -209,7 +210,8 @@ int main(int argc, char** argv)
     app.run< SegmentedReductionHierarchical<int>>();
     app.run< SegmentedReductionHierarchical<long long>>();
     app.run< SegmentedReductionHierarchical<float>>();
-    app.run< SegmentedReductionHierarchical<double>>();
+    if(app.deviceSupportsFP64())
+      app.run<SegmentedReductionHierarchical<double>>();
   }
 
   return 0;

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -198,6 +198,7 @@ class Polybench_Fdtd2d {
 
 int main(int argc, char** argv) {
 	BenchmarkApp app(argc, argv);
-	app.run<Polybench_Fdtd2d>();
-	return 0;
+        if(app.deviceSupportsFP64())
+          app.run<Polybench_Fdtd2d>();
+        return 0;
 }

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -198,7 +198,7 @@ class Polybench_Fdtd2d {
 
 int main(int argc, char** argv) {
 	BenchmarkApp app(argc, argv);
-        if(app.deviceSupportsFP64())
-          app.run<Polybench_Fdtd2d>();
-        return 0;
+	if(app.deviceSupportsFP64())
+		app.run<Polybench_Fdtd2d>();
+	return 0;
 }

--- a/single-kernel/kmeans.cpp
+++ b/single-kernel/kmeans.cpp
@@ -126,6 +126,7 @@ int main(int argc, char** argv)
 {
   BenchmarkApp app(argc, argv);
   app.run<KmeansBench<float>> ();
-  app.run<KmeansBench<double>> ();   
+  if(app.deviceSupportsFP64())
+    app.run<KmeansBench<double>>();
   return 0;
 }

--- a/single-kernel/lin_reg_coeff.cpp
+++ b/single-kernel/lin_reg_coeff.cpp
@@ -195,7 +195,8 @@ int main(int argc, char** argv)
   BenchmarkApp app(argc, argv);
   if(app.shouldRunNDRangeKernels()){
     app.run<LinearRegressionCoeffBench<float>>();
-    app.run<LinearRegressionCoeffBench<double>>();   
+    if(app.deviceSupportsFP64())
+      app.run<LinearRegressionCoeffBench<double>>();
   }
   return 0;
 }

--- a/single-kernel/lin_reg_error.cpp
+++ b/single-kernel/lin_reg_error.cpp
@@ -132,6 +132,7 @@ int main(int argc, char** argv)
 {
   BenchmarkApp app(argc, argv);
   app.run<LinearRegressionBench<float>>();
-  app.run<LinearRegressionBench<double>>();   
+  if(app.deviceSupportsFP64())
+    app.run<LinearRegressionBench<double>>();
   return 0;
 }

--- a/single-kernel/nbody.cpp
+++ b/single-kernel/nbody.cpp
@@ -322,12 +322,14 @@ int main(int argc, char** argv)
 
   if(app.shouldRunHierarchicalKernels()) {
     app.run< NBodyHierarchical<float> >();
-    app.run< NBodyHierarchical<double> >();
+    if(app.deviceSupportsFP64())
+      app.run<NBodyHierarchical<double>>();
   }
 
   if(app.shouldRunNDRangeKernels()) {
     app.run< NBodyNDRange<float> >();
-    app.run< NBodyNDRange<double> >();
+    if(app.deviceSupportsFP64())
+      app.run<NBodyNDRange<double>>();
   }
 
   return 0;

--- a/single-kernel/scalar_prod.cpp
+++ b/single-kernel/scalar_prod.cpp
@@ -230,14 +230,16 @@ int main(int argc, char** argv)
     app.run<ScalarProdBench<int, true>>();
     app.run<ScalarProdBench<long long, true>>();
     app.run<ScalarProdBench<float, true>>();
-    app.run<ScalarProdBench<double, true>>();
+    if(app.deviceSupportsFP64())
+      app.run<ScalarProdBench<double, true>>();
   }
 
   if(app.shouldRunHierarchicalKernels()) {
     app.run<ScalarProdBench<int, false>>();
     app.run<ScalarProdBench<long long, false>>();
     app.run<ScalarProdBench<float, false>>();
-    app.run<ScalarProdBench<double, false>>();
+    if(app.deviceSupportsFP64())
+      app.run<ScalarProdBench<double, false>>();
   }
 
   return 0;

--- a/single-kernel/vec_add.cpp
+++ b/single-kernel/vec_add.cpp
@@ -89,6 +89,7 @@ int main(int argc, char** argv)
   app.run<VecAddBench<int>>();
   app.run<VecAddBench<long long>>();  
   app.run<VecAddBench<float>>();
-  app.run<VecAddBench<double>>();
+  if(app.deviceSupportsFP64())
+    app.run<VecAddBench<double>>();
   return 0;
 }


### PR DESCRIPTION
Check `fp64` aspect at runtime before launching benchmarks using that type. This will allow runtime errors on devices lacking that aspect.