### PR TITLE
Add `mol_dyn` to `--mlir-only` runs

### DIFF
--- a/bin/run-suite
+++ b/bin/run-suite
@@ -59,7 +59,6 @@ non_mlir = {
   "host_device_bandwidth",
   "local_mem",
   "matmulchain",
-  "mol_dyn",
   "pattern_L2",
   "reduction",
   "segmentedreduction",


### PR DESCRIPTION
Run `mol_dyn` as part of `--mlir-only` runs.