### PR TITLE
Update to support AdaptiveCpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(${CMAKE_SOURCE_DIR}/polybench/common)
 
 set(supported_implementations
   ComputeCpp
-  hipSYCL
+  AdaptiveCpp
   LLVM
   LLVM-CUDA
   LLVM-MLIR
@@ -40,8 +40,8 @@ endif()
 
 if(SYCL_IMPL STREQUAL "ComputeCpp")
   find_package(ComputeCpp MODULE REQUIRED)
-elseif(SYCL_IMPL STREQUAL "hipSYCL")
-  find_package(hipSYCL CONFIG REQUIRED)
+elseif(SYCL_IMPL STREQUAL "AdaptiveCpp")
+  find_package(AdaptiveCpp CONFIG REQUIRED)
 elseif(SYCL_IMPL STREQUAL "LLVM")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fsycl-disable-range-rounding -fsycl -fsycl-device-code-split=per_kernel")
 elseif(SYCL_IMPL STREQUAL "LLVM-CUDA")
@@ -101,7 +101,7 @@ foreach(benchmark IN LISTS benchmarks)
 
   add_executable(${target} ${benchmark})
 
-  if(SYCL_IMPL STREQUAL "ComputeCpp" OR SYCL_IMPL STREQUAL "hipSYCL")
+  if(SYCL_IMPL STREQUAL "ComputeCpp" OR SYCL_IMPL STREQUAL "AdaptiveCpp")
     add_sycl_to_target(TARGET ${target} SOURCES ${benchmark})
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Due to CMake limitations, hipSYCL requires C++ standard to be set manually
+# Due to CMake limitations, AdaptiveCpp requires C++ standard to be set manually
 set(CMAKE_SYCL_FLAGS "${CMAKE_SYCL_FLAGS} -std=c++17")
 
 if(CMAKE_GENERATOR STREQUAL "Ninja")

--- a/include/common.h
+++ b/include/common.h
@@ -150,8 +150,8 @@ private:
   std::vector<BenchmarkHook*> hooks;
 
   std::string getSyclImplementation() const {
-#if defined(__HIPSYCL__)
-    return "hipSYCL";
+#if defined(__ACPP__)
+    return "AdaptiveCpp";
 #elif defined(__COMPUTECPP__)
     return "ComputeCpp";
 #elif defined(__LLVM_SYCL__)

--- a/single-kernel/mol_dyn.cpp
+++ b/single-kernel/mol_dyn.cpp
@@ -132,7 +132,7 @@ public:
             j++;
         }
 
-        if(sycl::distance(f, output_acc[i]) / sycl::length(f) > maxErr) {
+        if(s::distance(f, output_acc[i]) / s::length(f) > maxErr) {
           pass = false;
           break;
         }


### PR DESCRIPTION
Update the CMake to support the new AdaptiveCpp instead of its predecessor, hipSYCL.